### PR TITLE
Use native http and https node modules to do api requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,10 @@
       "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
-        "bonjour-service": "^1.0.14",
-        "node-fetch": "^3.1.0"
+        "bonjour-service": "^1.0.14"
       },
       "devDependencies": {
         "@types/node": "^18.11.10",
-        "@types/node-fetch": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
         "dotenv-cli": "^6.0.0",
@@ -721,15 +719,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
       "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
       "dev": true
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.2.tgz",
-      "integrity": "sha512-3q5FyT6iuekUxXeL2qjcyIhtMJdfMF7RGhYXWKkYpdcW9k36A/+txXrjG0l+NMVkiC30jKNrcOqVlqBl7BcCHA==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "*"
-      }
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -3148,6 +3137,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3284,6 +3274,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -5691,6 +5682,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5703,31 +5695,6 @@
       ],
       "engines": {
         "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.0.tgz",
-      "integrity": "sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.2",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/node-fetch/node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/node-persist": {
@@ -8045,6 +8012,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -8901,15 +8869,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
       "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
       "dev": true
-    },
-    "@types/node-fetch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.2.tgz",
-      "integrity": "sha512-3q5FyT6iuekUxXeL2qjcyIhtMJdfMF7RGhYXWKkYpdcW9k36A/+txXrjG0l+NMVkiC30jKNrcOqVlqBl7BcCHA==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "*"
-      }
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -10570,6 +10529,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -10662,6 +10622,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "requires": {
         "fetch-blob": "^3.1.2"
       }
@@ -12350,24 +12311,8 @@
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.0.tgz",
-      "integrity": "sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.2",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "dependencies": {
-        "data-uri-to-buffer": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-          "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-        }
-      }
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true
     },
     "node-persist": {
       "version": "0.0.11",
@@ -13973,7 +13918,8 @@
     "web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   ],
   "devDependencies": {
     "@types/node": "^18.11.10",
-    "@types/node-fetch": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "dotenv-cli": "^6.0.0",
@@ -64,8 +63,7 @@
     "vitest": "^0.25.3"
   },
   "dependencies": {
-    "bonjour-service": "^1.0.14",
-    "node-fetch": "^3.1.0"
+    "bonjour-service": "^1.0.14"
   },
   "release-it": {
     "git": {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,7 @@ import {
   HomeWizardApiStatePutResponse,
   HomeWizardApiStateResponse,
 } from "@/api/types";
-import { httpRequest, HttpRequestResponse } from "@/http-request";
+import { httpRequest, HttpRequestResponse } from "@/utils/http-request";
 
 interface Endpoints {
   basic: string;
@@ -75,7 +75,7 @@ export class HomeWizardApi {
       return this.throwApiError(method, response);
     }
 
-    const data = response.data;
+    const data = await response.json();
 
     this.log.debug(
       this.loggerPrefix,
@@ -108,7 +108,7 @@ export class HomeWizardApi {
       return this.throwApiError(method, response);
     }
 
-    const data = response.data;
+    const data = await response.json();
 
     this.log.info(
       this.loggerPrefix,
@@ -138,7 +138,7 @@ export class HomeWizardApi {
       this.endpoints.state,
       {
         method,
-        data: params,
+        body: JSON.stringify(params),
       }
     );
 
@@ -146,7 +146,7 @@ export class HomeWizardApi {
       return this.throwApiError(method, response);
     }
 
-    const data = response.data;
+    const data = await response.json();
 
     this.log.debug(
       this.loggerPrefix,
@@ -195,7 +195,7 @@ export class HomeWizardApi {
       return this.throwApiError(method, response);
     }
 
-    const data = response.data;
+    const data = await response.json();
 
     this.log.debug(
       this.loggerPrefix,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,4 @@
 import { Logger } from "homebridge";
-import nodeFetch, { Response } from "node-fetch";
 import {
   HomeWizardApiBasicInformationResponse,
   HomeWizardApiIdentifyResponse,
@@ -7,6 +6,7 @@ import {
   HomeWizardApiStatePutResponse,
   HomeWizardApiStateResponse,
 } from "@/api/types";
+import { httpRequest, HttpRequestResponse } from "@/http-request";
 
 interface Endpoints {
   basic: string;
@@ -35,15 +35,16 @@ export class HomeWizardApi {
     };
   }
 
-  async throwApiError(method: string, response: Response): Promise<never> {
-    const responseData = await response.json();
-
+  async throwApiError<T>(
+    method: string,
+    response: HttpRequestResponse<T>
+  ): Promise<never> {
     throw new Error(
       `Api ${method.toUpperCase()} call at ${
         response.url
       } failed, with status ${
         response.status
-      } and response data ${JSON.stringify(responseData)}`
+      } and response data ${JSON.stringify(response)}`
     );
   }
 
@@ -63,16 +64,18 @@ export class HomeWizardApi {
     );
 
     const method = "GET";
-    const response = await nodeFetch(this.endpoints.basic, {
-      method,
-    });
+    const response = await httpRequest<HomeWizardApiBasicInformationResponse>(
+      this.endpoints.basic,
+      {
+        method,
+      }
+    );
 
     if (!response.ok) {
       return this.throwApiError(method, response);
     }
 
-    const data =
-      (await response.json()) as unknown as HomeWizardApiBasicInformationResponse;
+    const data = response.data;
 
     this.log.debug(
       this.loggerPrefix,
@@ -94,16 +97,18 @@ export class HomeWizardApi {
     );
 
     const method = "GET";
-    const response = await nodeFetch(this.endpoints.state, {
-      method,
-    });
+    const response = await httpRequest<HomeWizardApiStateResponse>(
+      this.endpoints.state,
+      {
+        method,
+      }
+    );
 
     if (!response.ok) {
       return this.throwApiError(method, response);
     }
 
-    const data =
-      (await response.json()) as unknown as HomeWizardApiStateResponse;
+    const data = response.data;
 
     this.log.info(
       this.loggerPrefix,
@@ -129,17 +134,19 @@ export class HomeWizardApi {
     );
 
     const method = "PUT";
-    const response = await nodeFetch(this.endpoints.state, {
-      method,
-      body: JSON.stringify(params),
-    });
+    const response = await httpRequest<HomeWizardApiStatePutResponse>(
+      this.endpoints.state,
+      {
+        method,
+        data: params,
+      }
+    );
 
     if (!response.ok) {
       return this.throwApiError(method, response);
     }
 
-    const data =
-      (await response.json()) as unknown as HomeWizardApiStatePutResponse;
+    const data = response.data;
 
     this.log.debug(
       this.loggerPrefix,
@@ -177,16 +184,18 @@ export class HomeWizardApi {
 
     const method = "PUT";
 
-    const response = await nodeFetch(this.endpoints.identify, {
-      method,
-    });
+    const response = await httpRequest<HomeWizardApiIdentifyResponse>(
+      this.endpoints.identify,
+      {
+        method,
+      }
+    );
 
     if (!response.ok) {
       return this.throwApiError(method, response);
     }
 
-    const data =
-      (await response.json()) as unknown as HomeWizardApiIdentifyResponse;
+    const data = response.data;
 
     this.log.debug(
       this.loggerPrefix,

--- a/src/http-request.ts
+++ b/src/http-request.ts
@@ -1,0 +1,90 @@
+import https from "https";
+import http, { RequestOptions, IncomingHttpHeaders } from "http";
+
+export interface HttpRequestResponse<T> {
+  readonly headers: IncomingHttpHeaders;
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string | undefined;
+  readonly url: string;
+  readonly data: T;
+}
+
+type HttpRequestOptions = Omit<
+  RequestOptions,
+  "protocol" | "host" | "path" | "port" | "hostname" | "localAddress" | "href"
+> & {
+  data?: object;
+};
+
+export const httpRequest = <T>(
+  url: string,
+  options: HttpRequestOptions
+): Promise<HttpRequestResponse<T>> =>
+  new Promise((resolve, reject) => {
+    let request = http.request;
+
+    if (url.startsWith("https")) {
+      request = https.request;
+    }
+
+    const { host, pathname, protocol, port } = new URL(url);
+
+    const req = request(
+      {
+        protocol,
+        host,
+        path: pathname,
+        port,
+        headers: {
+          "Content-Type": "application/json",
+          ...options.headers,
+        },
+        ...options,
+      },
+      (res) => {
+        const body = new Array<Buffer | string>();
+        const statusText = res.statusMessage;
+
+        res.setEncoding("utf8");
+
+        res.on("data", (chunk) => body.push(chunk));
+        res.on("error", reject);
+        res.on("end", () => {
+          const { statusCode, headers } = res;
+          const joinedBody = body.join("");
+
+          if (!statusCode) {
+            return reject(
+              new Error(
+                `Request failed. No status code returned. Response body: ${joinedBody}`
+              )
+            );
+          }
+
+          const ok = !!(statusCode && statusCode < 400);
+
+          const data = JSON.parse(joinedBody) as T;
+
+          const response: HttpRequestResponse<T> = {
+            ok,
+            headers,
+            data,
+            status: statusCode,
+            statusText,
+            url,
+          };
+
+          return resolve(response);
+        });
+      }
+    );
+
+    req.on("error", reject);
+
+    if (options.data) {
+      req.write(JSON.stringify(options.data));
+    }
+
+    req.end();
+  });


### PR DESCRIPTION
simpler, no dependencies

node-fetch was having issues in node 18. Kept hanging on `response.json()` after a PUT request and never resolves.

- [x] keep parameters similar to node-fetch, so we can switch back when node-fetch has their issues fixed for node 18