### PR TITLE
Feat: use OutletInUse characteristic to determine if a device is drawing power

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -51,7 +51,7 @@
                   "default": 5,
                   "minimum": 0.1,
                   "maximum": 3680,
-                  "description": "When the power consumption is higher than this threshold, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Otherwise it shows \"No\". Defaults to 1 watt.",
+                  "description": "When the power consumption is higher than this threshold, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Otherwise it shows \"No\". Defaults to 5 watt.",
                   "condition": {
                     "functionBody": "return model.energySockets[arrayIndices].outletInUse.isActive === true;"
                   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -22,12 +22,54 @@
           "properties": {
             "name": {
               "type": "string",
+              "title": "Name",
+              "placeholder": "What is plugged in?",
               "required": true
             },
             "ip": {
               "type": "string",
+              "title": "IP Address",
+              "placeholder": "192.168.0.10",
               "format": "ipv4",
               "required": true
+            },
+            "outletInUse": {
+              "type": "object",
+              "properties": {
+                "isActive": {
+                  "title": "Use Outlet in Use?",
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "description": "When enabled, the \"Outlet In Use\" characteristic will be shown as \"Yes\" if the Energy Socket is drawing power. You can trigger automations based on this characteristic. By default this characteristic is \"No\"."
+                },
+                "threshold": {
+                  "title": "Threshold (watts)",
+                  "placeholder": "Power usage in watts",
+                  "type": "number",
+                  "required": true,
+                  "default": 5,
+                  "minimum": 0.1,
+                  "maximum": 3680,
+                  "description": "When the power consumption is higher than this threshold, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Defaults to 1 watt.",
+                  "condition": {
+                    "functionBody": "return model.energySockets[arrayIndices].outletInUse.isActive === true;"
+                  }
+                },
+                "thresholdDuration": {
+                  "title": "Threshold Duration (seconds)",
+                  "placeholder": "Duration in seconds",
+                  "type": "number",
+                  "required": true,
+                  "default": 10,
+                  "minimum": 0,
+                  "maximum": 86400,
+                  "description": "When the power consumption is higher than the threshold for this duration, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Defaults to 10 seconds.",
+                  "condition": {
+                    "functionBody": "return model.energySockets[arrayIndices].outletInUse.isActive === true;"
+                  }
+                }
+              }
             }
           }
         }
@@ -38,6 +80,7 @@
     {
       "type": "flex",
       "flex-flow": "row wrap",
+      "orderable": false,
       "items": [
         {
           "key": "name",
@@ -50,6 +93,7 @@
       "title": "Energy Sockets",
       "description": "<strong>This config option is optional.</strong> Only use this if you want to bypass automatic discovery or use only the Energy Sockets you define here. When no Energy Sockets are defined here, the plugin will automatically discover all Energy Sockets on your network.",
       "expandable": true,
+      "orderable": false,
       "items": [
         {
           "type": "help",
@@ -60,20 +104,38 @@
           "key": "energySockets",
           "type": "array",
           "notitle": true,
+          "orderable": false,
           "items": [
             {
               "type": "flex",
               "flex-flow": "row wrap",
               "items": [
                 {
-                  "key": "energySockets[].name",
-                  "title": "Name",
-                  "placeholder": "What is plugged in?"
+                  "type": "flex",
+                  "flex-flow": "row wrap",
+                  "items": [
+                    {
+                      "key": "energySockets[].name"
+                    },
+                    {
+                      "key": "energySockets[].ip"
+                    }
+                  ]
                 },
                 {
-                  "key": "energySockets[].ip",
-                  "title": "IP Address",
-                  "placeholder": "192.168.0.10"
+                  "type": "flex",
+                  "flex-flow": "row wrap",
+                  "items": [
+                    {
+                      "key": "energySockets[].outletInUse.isActive"
+                    },
+                    {
+                      "key": "energySockets[].outletInUse.threshold"
+                    },
+                    {
+                      "key": "energySockets[].outletInUse.thresholdDuration"
+                    }
+                  ]
                 }
               ]
             }

--- a/config.schema.json
+++ b/config.schema.json
@@ -41,7 +41,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "description": "When enabled, the \"Outlet In Use\" characteristic will be shown as \"Yes\" if the Energy Socket is drawing power. You can trigger automations based on this characteristic. By default this characteristic is \"No\"."
+                  "description": "When enabled, the \"Outlet In Use\" characteristic will be shown as \"Yes\" if the device plugged in the Energy Socket is consuming a certain amount of power. You can trigger automations based on this characteristic.<br /><a href='https://github.com/jvandenaardweg/homebridge-homewizard-energy-socket/wiki/About-the-Outlet-In-Use-characteristic' target='_blank'>Learn more about it in the Wiki</a>."
                 },
                 "threshold": {
                   "title": "Threshold (watts)",
@@ -51,7 +51,7 @@
                   "default": 5,
                   "minimum": 0.1,
                   "maximum": 3680,
-                  "description": "When the power consumption is higher than this threshold, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Defaults to 1 watt.",
+                  "description": "When the power consumption is higher than this threshold, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Otherwise it shows \"No\". Defaults to 1 watt.",
                   "condition": {
                     "functionBody": "return model.energySockets[arrayIndices].outletInUse.isActive === true;"
                   }
@@ -64,7 +64,7 @@
                   "default": 10,
                   "minimum": 0,
                   "maximum": 86400,
-                  "description": "When the power consumption is higher than the threshold for this duration, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Defaults to 10 seconds.",
+                  "description": "When the power consumption is higher than the threshold for this duration, the \"Outlet In Use\" characteristic will be shown as \"Yes\" in the Home app. Otherwise it shows \"No\". Defaults to 10 seconds.",
                   "condition": {
                     "functionBody": "return model.energySockets[arrayIndices].outletInUse.isActive === true;"
                   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,13 @@
       "license": "MIT",
       "dependencies": {
         "bonjour-service": "^1.0.14",
-        "undici": "^5.14.0"
+        "undici": "^5.14.0",
+        "validator": "^13.7.0",
+        "zod": "^3.20.2"
       },
       "devDependencies": {
         "@types/node": "^18.11.13",
+        "@types/validator": "^13.7.10",
         "@typescript-eslint/eslint-plugin": "^5.46.0",
         "@typescript-eslint/parser": "^5.46.0",
         "@vitest/coverage-c8": "^0.25.7",
@@ -644,6 +647,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7508,6 +7517,14 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vite": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
@@ -7959,6 +7976,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+      "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   },
@@ -8419,6 +8444,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "@types/validator": {
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -13220,6 +13251,11 @@
         }
       }
     },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+    },
     "vite": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
@@ -13505,6 +13541,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+      "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   ],
   "devDependencies": {
     "@types/node": "^18.11.13",
+    "@types/validator": "^13.7.10",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
     "@vitest/coverage-c8": "^0.25.7",
@@ -90,7 +91,9 @@
   },
   "dependencies": {
     "bonjour-service": "^1.0.14",
-    "undici": "^5.14.0"
+    "undici": "^5.14.0",
+    "validator": "^13.7.0",
+    "zod": "^3.20.2"
   },
   "release-it": {
     "git": {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -244,12 +244,15 @@ export class HomeWizardApi {
    */
   async getData<T extends EnergySocketDataResponse>(
     productType: HomeWizardDeviceTypes.WIFI_ENERGY_SOCKET,
+    disableLogs?: boolean,
   ): Promise<T>;
   async getData<T extends P1MeterDataResponse>(
     productType: HomeWizardDeviceTypes.WIFI_PI_METER,
+    disableLogs?: boolean,
   ): Promise<T>;
   async getData<T extends EnergySocketDataResponse | P1MeterDataResponse>(
     productType: HomeWizardDeviceTypes.WIFI_PI_METER | HomeWizardDeviceTypes.WIFI_ENERGY_SOCKET,
+    disableLogs?: boolean,
   ): Promise<T> {
     if (
       productType !== HomeWizardDeviceTypes.WIFI_PI_METER &&
@@ -262,7 +265,9 @@ export class HomeWizardApi {
 
     const url = this.endpoints.data;
 
-    this.log.debug(this.loggerPrefix, `Fetching the data at ${url}`);
+    if (!disableLogs) {
+      this.log.debug(this.loggerPrefix, `Fetching the data at ${url}`);
+    }
 
     const method = 'GET';
     const response = await request(url, {
@@ -275,7 +280,9 @@ export class HomeWizardApi {
 
     const data = (await response.body.json()) as T;
 
-    this.log.debug(this.loggerPrefix, `Fetched data: ${JSON.stringify(data)}`);
+    if (!disableLogs) {
+      this.log.debug(this.loggerPrefix, `Fetched data: ${JSON.stringify(data)}`);
+    }
 
     return data;
   }

--- a/src/api/mocks/api.ts
+++ b/src/api/mocks/api.ts
@@ -1,7 +1,9 @@
+import { HomeWizardDeviceTypes } from '../types';
+
 export const mockHostname = 'localhost';
 export const mockApiUrl = `http://${mockHostname}`;
 export const mockSerialNumber = '1234567890';
 export const mockFirmwareVersion = '3.1';
-export const mockProductType = 'HWE-SKT';
+export const mockProductType = HomeWizardDeviceTypes.WIFI_ENERGY_SOCKET;
 export const mockProductName = 'Energy Socket';
 export const mockApiVersion = 'v1';

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,3 +1,5 @@
+import { EnergySocketConfig } from '@/types';
+
 export const PLATFORM_MANUFACTURER = 'HomeWizard';
 
 /**
@@ -60,6 +62,8 @@ export interface EnergySocketAccessoryProperties {
   /** The name we display to the user during first setup in the Home App, like: `"Energy Socket 3c12e7659852"` */
   displayName: string;
   firmwareVersion: string;
+  activePower: number | null;
+  config?: EnergySocketConfig;
 }
 
 /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -43,12 +43,8 @@ export interface TxtRecord {
 export interface EnergySocketAccessoryProperties {
   /** Accessory UUID, used to identify the accessory within HomeBridge. This uuid is generated from the `id` and `serialNumber`, which are the same. */
   uuid: string;
-  /** Hostname of the device. Example: `"energysocket-185952.local"` */
-  // hostname: string;
   /** The IP address of the device. Example: `"192.168.1.20"` */
   ip: string;
-  /** The port at which the API of this device is running. Example: 80 */
-  // port: number;
   /** The version of the API. Example: `"v1"` */
   apiVersion: string;
   /** The API url of this device, without trailing slash. Example: "`http://192.168.1.20`" */
@@ -61,8 +57,11 @@ export interface EnergySocketAccessoryProperties {
   productType: HomeWizardDeviceTypes;
   /** The name we display to the user during first setup in the Home App, like: `"Energy Socket 3c12e7659852"` */
   displayName: string;
+  /** The firmware version of the device. Some API features are not available based on the firmware version. Example: `"3.0"` */
   firmwareVersion: string;
+  /** The initial active power value in watts. Example: `2.45` */
   activePower: number | null;
+  /** The config options for this energy socket as defined by the user. Attached to this energy socket by IP. */
   config?: EnergySocketConfig;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -56,7 +56,7 @@ export interface EnergySocketAccessoryProperties {
   /** The product name of this device. Example: `"Energy Socket"` */
   productName: string;
   /** A device type identifier. Example: `"HWE-SKT"` */
-  productType: string;
+  productType: HomeWizardDeviceTypes;
   /** The name we display to the user during first setup in the Home App, like: `"Energy Socket 3c12e7659852"` */
   displayName: string;
   firmwareVersion: string;

--- a/src/config.schema.test.ts
+++ b/src/config.schema.test.ts
@@ -41,16 +41,16 @@ describe('config.schema.json', () => {
 
     // outletInUse threshold
     expect(outletInUseProperties.threshold.type).toBe('number');
-    expect(outletInUseProperties.threshold.default).toBe(5);
-    expect(DEFAULT_OUTLETINUSE_THRESHOLD).toBe(5);
+    expect(outletInUseProperties.threshold.default).toBe(DEFAULT_OUTLETINUSE_THRESHOLD);
     expect(outletInUseProperties.threshold.minimum).toBe(0.1); // do not allow 0, as that would mean that the outlet is always in use, which is not where this config option is for
     expect(outletInUseProperties.threshold.maximum).toBe(3680); // the max power of a socket is 3680W, see: https://www.homewizard.com/energy-socket/
     expect(outletInUseProperties.threshold.required).toBe(true);
 
     // outletInUse thresholdDuration
     expect(outletInUseProperties.thresholdDuration.type).toBe('number');
-    expect(outletInUseProperties.thresholdDuration.default).toBe(10);
-    expect(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION).toBe(10);
+    expect(outletInUseProperties.thresholdDuration.default).toBe(
+      DEFAULT_OUTLETINUSE_THRESHOLD_DURATION,
+    );
     expect(outletInUseProperties.thresholdDuration.minimum).toBe(0);
     expect(outletInUseProperties.thresholdDuration.maximum).toBe(86400); // 1 day in seconds
     expect(outletInUseProperties.thresholdDuration.required).toBe(true);

--- a/src/config.schema.test.ts
+++ b/src/config.schema.test.ts
@@ -1,13 +1,19 @@
 import configSchemaJson from '../config.schema.json';
-import { DEFAULT_OUTLETINUSE_THRESHOLD, DEFAULT_OUTLETINUSE_THRESHOLD_DURATION } from './settings';
-
-import { HomebridgeHomeWizardEnergySocketsConfig } from './types';
+import {
+  ConfigSchema,
+  DEFAULT_OUTLETINUSE_THRESHOLD,
+  DEFAULT_OUTLETINUSE_THRESHOLD_DURATION,
+  DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MAX,
+  DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MIN,
+  DEFAULT_OUTLETINUSE_THRESHOLD_MAX,
+  DEFAULT_OUTLETINUSE_THRESHOLD_MIN,
+} from './config.schema';
 
 // Sanity check, as we don't import config.schema.json in our code, we have no type-safety over the config.schema.json values and our types
 // These tests will fail if we change names or requirements in config.schema.json that are not reflected in our types
 describe('config.schema.json', () => {
-  it('Should have the correct energySocket property', async () => {
-    const energySocketsProperty: keyof HomebridgeHomeWizardEnergySocketsConfig = 'energySockets';
+  it('should have the correct energySocket property', async () => {
+    const energySocketsProperty: keyof ConfigSchema = 'energySockets';
 
     const properties = configSchemaJson.schema.properties;
 
@@ -42,8 +48,8 @@ describe('config.schema.json', () => {
     // outletInUse threshold
     expect(outletInUseProperties.threshold.type).toBe('number');
     expect(outletInUseProperties.threshold.default).toBe(DEFAULT_OUTLETINUSE_THRESHOLD);
-    expect(outletInUseProperties.threshold.minimum).toBe(0.1); // do not allow 0, as that would mean that the outlet is always in use, which is not where this config option is for
-    expect(outletInUseProperties.threshold.maximum).toBe(3680); // the max power of a socket is 3680W, see: https://www.homewizard.com/energy-socket/
+    expect(outletInUseProperties.threshold.minimum).toBe(DEFAULT_OUTLETINUSE_THRESHOLD_MIN); // do not allow 0, as that would mean that the outlet is always in use, which is not where this config option is for
+    expect(outletInUseProperties.threshold.maximum).toBe(DEFAULT_OUTLETINUSE_THRESHOLD_MAX); // the max power of a socket is 3680W, see: https://www.homewizard.com/energy-socket/
     expect(outletInUseProperties.threshold.required).toBe(true);
 
     // outletInUse thresholdDuration
@@ -51,13 +57,17 @@ describe('config.schema.json', () => {
     expect(outletInUseProperties.thresholdDuration.default).toBe(
       DEFAULT_OUTLETINUSE_THRESHOLD_DURATION,
     );
-    expect(outletInUseProperties.thresholdDuration.minimum).toBe(0);
-    expect(outletInUseProperties.thresholdDuration.maximum).toBe(86400); // 1 day in seconds
+    expect(outletInUseProperties.thresholdDuration.minimum).toBe(
+      DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MIN,
+    );
+    expect(outletInUseProperties.thresholdDuration.maximum).toBe(
+      DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MAX,
+    ); // 1 day in seconds
     expect(outletInUseProperties.thresholdDuration.required).toBe(true);
   });
 
-  it('Should have the correct name property', async () => {
-    const nameProperty: keyof HomebridgeHomeWizardEnergySocketsConfig = 'name';
+  it('should have the correct name property', async () => {
+    const nameProperty: keyof ConfigSchema = 'name';
 
     const properties = configSchemaJson.schema.properties;
 

--- a/src/config.schema.test.ts
+++ b/src/config.schema.test.ts
@@ -17,14 +17,40 @@ describe('config.schema.json', () => {
 
     expect(properties.energySockets.items.type).toBe('object');
 
+    const energySocketProperties = properties.energySockets.items.properties;
+
     // name
-    expect(properties.energySockets.items.properties.name.type).toBe('string');
-    expect(properties.energySockets.items.properties.name.required).toBe(true);
+    expect(energySocketProperties.name.type).toBe('string');
+    expect(energySocketProperties.name.required).toBe(true);
 
     // ip
-    expect(properties.energySockets.items.properties.ip.type).toBe('string');
-    expect(properties.energySockets.items.properties.ip.required).toBe(true);
-    expect(properties.energySockets.items.properties.ip.format).toBe('ipv4');
+    expect(energySocketProperties.ip.type).toBe('string');
+    expect(energySocketProperties.ip.required).toBe(true);
+    expect(energySocketProperties.ip.format).toBe('ipv4');
+
+    // outletInUse
+    expect(energySocketProperties.outletInUse.type).toBe('object');
+
+    const outletInUseProperties = energySocketProperties.outletInUse.properties;
+
+    // outletInUse isActive
+    expect(outletInUseProperties.isActive.type).toBe('boolean');
+    expect(outletInUseProperties.isActive.default).toBe(false);
+    expect(outletInUseProperties.isActive.required).toBe(false);
+
+    // outletInUse threshold
+    expect(outletInUseProperties.threshold.type).toBe('number');
+    expect(outletInUseProperties.threshold.default).toBe(5);
+    expect(outletInUseProperties.threshold.minimum).toBe(0.1); // do not allow 0, as that would mean that the outlet is always in use, which is not where this config option is for
+    expect(outletInUseProperties.threshold.maximum).toBe(3680); // the max power of a socket is 3680W, see: https://www.homewizard.com/energy-socket/
+    expect(outletInUseProperties.threshold.required).toBe(true);
+
+    // outletInUse thresholdDuration
+    expect(outletInUseProperties.thresholdDuration.type).toBe('number');
+    expect(outletInUseProperties.thresholdDuration.default).toBe(10);
+    expect(outletInUseProperties.thresholdDuration.minimum).toBe(0);
+    expect(outletInUseProperties.thresholdDuration.maximum).toBe(86400); // 1 day in seconds
+    expect(outletInUseProperties.thresholdDuration.required).toBe(true);
   });
 
   it('Should have the correct name property', async () => {

--- a/src/config.schema.test.ts
+++ b/src/config.schema.test.ts
@@ -1,4 +1,5 @@
 import configSchemaJson from '../config.schema.json';
+import { DEFAULT_OUTLETINUSE_THRESHOLD, DEFAULT_OUTLETINUSE_THRESHOLD_DURATION } from './settings';
 
 import { HomebridgeHomeWizardEnergySocketsConfig } from './types';
 
@@ -41,6 +42,7 @@ describe('config.schema.json', () => {
     // outletInUse threshold
     expect(outletInUseProperties.threshold.type).toBe('number');
     expect(outletInUseProperties.threshold.default).toBe(5);
+    expect(DEFAULT_OUTLETINUSE_THRESHOLD).toBe(5);
     expect(outletInUseProperties.threshold.minimum).toBe(0.1); // do not allow 0, as that would mean that the outlet is always in use, which is not where this config option is for
     expect(outletInUseProperties.threshold.maximum).toBe(3680); // the max power of a socket is 3680W, see: https://www.homewizard.com/energy-socket/
     expect(outletInUseProperties.threshold.required).toBe(true);
@@ -48,6 +50,7 @@ describe('config.schema.json', () => {
     // outletInUse thresholdDuration
     expect(outletInUseProperties.thresholdDuration.type).toBe('number');
     expect(outletInUseProperties.thresholdDuration.default).toBe(10);
+    expect(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION).toBe(10);
     expect(outletInUseProperties.thresholdDuration.minimum).toBe(0);
     expect(outletInUseProperties.thresholdDuration.maximum).toBe(86400); // 1 day in seconds
     expect(outletInUseProperties.thresholdDuration.required).toBe(true);

--- a/src/config.schema.test.ts
+++ b/src/config.schema.test.ts
@@ -1,5 +1,7 @@
+import { ZodError } from 'zod';
 import configSchemaJson from '../config.schema.json';
 import {
+  configSchema,
   ConfigSchema,
   DEFAULT_OUTLETINUSE_THRESHOLD,
   DEFAULT_OUTLETINUSE_THRESHOLD_DURATION,
@@ -8,6 +10,7 @@ import {
   DEFAULT_OUTLETINUSE_THRESHOLD_MAX,
   DEFAULT_OUTLETINUSE_THRESHOLD_MIN,
 } from './config.schema';
+import { PLATFORM_NAME } from './settings';
 
 // Sanity check, as we don't import config.schema.json in our code, we have no type-safety over the config.schema.json values and our types
 // These tests will fail if we change names or requirements in config.schema.json that are not reflected in our types
@@ -77,5 +80,269 @@ describe('config.schema.json', () => {
     expect(properties.name.required).toBe(true);
     expect(properties.name.type).toBe('string');
     expect(properties.name.default).toBe('HomeWizard Energy Socket');
+  });
+
+  it('should succeed the validation with valid config values', () => {
+    const configSchemaValues: ConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [
+        {
+          name: 'Energy Socket 1',
+          ip: '192.168.1.20',
+          outletInUse: {
+            isActive: true,
+            threshold: 5,
+            thresholdDuration: 60,
+          },
+        },
+      ],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(configSchemaValues);
+    };
+
+    expect(schemaValidation).not.toThrowError();
+  });
+
+  it('should error when bridge Name is missing', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError('A bridge name is required');
+  });
+
+  it('should not error when there is no energySockets array', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).not.toThrowError();
+  });
+
+  it('should not error when there is no energySockets array', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).not.toThrowError();
+  });
+
+  it('should error when the energySocket is missing a Name', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [{ ip: '192.168.1.20' }],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError('Name is required for each Energy Socket');
+  });
+
+  it('should error when the energySocket is missing an IP', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [
+        {
+          name: 'Energy Socket 1',
+        },
+      ],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError('IP address is required for each Energy Socket');
+  });
+
+  it('should error when the energySocket IP is not a valid ipv4 address', () => {
+    const mockIp = '192.168.1.';
+
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [{ name: 'Energy Socket 1', ip: mockIp }],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError(`'${mockIp}' is not a valid IPv4 address`);
+  });
+
+  it('should error when the energySocket IP is an empty string', () => {
+    const mockIp = '';
+
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [{ name: 'Energy Socket 1', ip: mockIp }],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError(`'${mockIp}' is not a valid IPv4 address`);
+  });
+
+  it('should error when the energySocket IP is not a valid ipv4 address', () => {
+    const mockIp = '2001:0db8:85a3:0000:0000:8a2e:0370:7334';
+
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [{ name: 'Energy Socket 1', ip: mockIp }],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError(`'${mockIp}' is not a valid IPv4 address`);
+  });
+
+  it('should error when the energySocket is an empty object', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [{}],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError();
+  });
+
+  it('should error when the energySocket outletInUse is active, but threshold and thresholdDuration are not set', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [
+        {
+          name: 'Energy Socket 1',
+          ip: '192.168.1.20',
+          outletInUse: {
+            isActive: true,
+          },
+        },
+      ],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    try {
+      schemaValidation();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        expect(error.errors[0].message).toBe(
+          'A threshold is required when outletInUse.isActive is true',
+        );
+        expect(error.errors[1].message).toBe(
+          'A thresholdDuration is required when outletInUse.isActive is true',
+        );
+      }
+    }
+  });
+
+  it('should error when the energySocket outletInUse is active, threshold is set but thresholdDuration is not set', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [
+        {
+          name: 'Energy Socket 1',
+          ip: '192.168.1.20',
+          outletInUse: {
+            isActive: true,
+            threshold: 5,
+          },
+        },
+      ],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError(
+      'A thresholdDuration is required when outletInUse.isActive is true',
+    );
+  });
+
+  it('should error when the energySocket outletInUse is active, thresholdDuration is set but threshold is not set', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [
+        {
+          name: 'Energy Socket 1',
+          ip: '192.168.1.20',
+          outletInUse: {
+            isActive: true,
+            thresholdDuration: 60,
+          },
+        },
+      ],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).toThrowError(
+      'A threshold is required when outletInUse.isActive is true',
+    );
+  });
+
+  it('should not error when outLetInUse.isActive is false and the other required fields are set', () => {
+    const invalidConfigSchema = {
+      platform: PLATFORM_NAME,
+      name: 'HomeWizard Energy Socket',
+      energySockets: [
+        {
+          name: 'Energy Socket 1',
+          ip: '192.168.1.20',
+          outletInUse: {
+            isActive: false,
+            threshold: 5,
+            thresholdDuration: 60,
+          },
+        },
+      ],
+    };
+
+    const schemaValidation = () => {
+      configSchema.parse(invalidConfigSchema);
+    };
+
+    expect(schemaValidation).not.toThrowError();
   });
 });

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -12,67 +12,84 @@ export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION = 10;
 export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MIN = 0;
 export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MAX = 86400;
 
-// validate the config schema from config.schema.json
+// this schema should match the config.schema.json
+// using zod to validate the config gives us type-safety over the config in our code
 export const configSchema = z.object({
-  name: z.string(),
-  energySockets: z.array(
-    z.object({
-      ip: z
-        .string({
-          required_error: 'IP address is required for each Energy Socket',
-        })
-        .refine(
-          ip => isIP(ip, 4),
-          ip => ({
-            message: `${ip} is not a valid IPv4 address`,
-          }),
-        ),
-      name: z.string({
-        required_error: 'Name is required for each Energy Socket',
-      }),
-      outletInUse: z
-        .object({
-          isActive: z.boolean().optional(),
-          threshold: z
-            .number()
-            .min(DEFAULT_OUTLETINUSE_THRESHOLD_MIN)
-            .max(DEFAULT_OUTLETINUSE_THRESHOLD_MAX)
-            .optional(), // set as optional, because it is only required when outletInUse.isActive is true. We'll use superRefine to validate this
-          thresholdDuration: z
-            .number()
-            .min(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MIN)
-            .max(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MAX)
-            .optional(), // set as optional, because it is only required when outletInUse.isActive is true. We'll use superRefine to validate this
-        })
-
-        .superRefine((schema, ctx) => {
-          const isActive = schema?.isActive;
-          const threshold = schema?.threshold;
-          const thresholdDuration = schema?.thresholdDuration;
-
-          // If isActive is true, threshold and thresholdDuration are required
-          if (isActive) {
-            if (!threshold) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['threshold'],
-                message: 'A threshold is required when outletInUse.isActive is true',
-              });
-            }
-
-            if (!thresholdDuration) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['thresholdDuration'],
-                message: 'A thresholdDuration is required when outletInUse.isActive is true',
-              });
-            }
-          }
-
-          return z.NEVER;
+  name: z.string({
+    required_error: 'A bridge name is required',
+  }),
+  energySockets: z
+    .array(
+      z.object({
+        ip: z
+          .string({
+            required_error: 'IP address is required for each Energy Socket',
+            invalid_type_error: "'ip' must be a string",
+          })
+          .refine(
+            ip => isIP(ip, 4),
+            ip => ({
+              message: `'${ip}' is not a valid IPv4 address`,
+            }),
+          ),
+        name: z.string({
+          required_error: 'Name is required for each Energy Socket',
+          invalid_type_error: "'name' must be a string",
         }),
-    }),
-  ),
+        outletInUse: z
+          .object({
+            isActive: z.boolean().optional(),
+            threshold: z
+              .number({
+                invalid_type_error: "'threshold' must be a number",
+              })
+              .min(DEFAULT_OUTLETINUSE_THRESHOLD_MIN)
+              .max(DEFAULT_OUTLETINUSE_THRESHOLD_MAX)
+              .optional(), // set as optional, because it is only required when outletInUse.isActive is true. We'll use superRefine to validate this
+            thresholdDuration: z
+              .number({
+                invalid_type_error: "'thresholdDuration' must be a number",
+              })
+              .min(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MIN)
+              .max(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MAX)
+              .optional(), // set as optional, because it is only required when outletInUse.isActive is true. We'll use superRefine to validate this
+          })
+
+          .superRefine((schema, ctx) => {
+            const isActive = schema?.isActive;
+            const threshold = schema?.threshold;
+            const thresholdDuration = schema?.thresholdDuration;
+
+            // If isActive is true, threshold and thresholdDuration are required
+            if (isActive) {
+              if (!threshold) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  path: ['threshold'],
+                  message: 'A threshold is required when outletInUse.isActive is true',
+                });
+              }
+
+              if (!thresholdDuration) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  path: ['thresholdDuration'],
+                  message: 'A thresholdDuration is required when outletInUse.isActive is true',
+                });
+              }
+            }
+
+            return z.NEVER;
+          }),
+      }),
+    )
+    .optional(),
+  // .refine(
+  //   array => Array.isArray(array) && array.length === 0,
+  //   () => ({
+  //     message: `Energy Sockets array cannot be empty. Either remove the array or add at least one Energy Socket`,
+  //   }),
+  // ),
 });
 
 export type ConfigSchema = z.infer<typeof configSchema> & PlatformConfig;

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import isIP from 'validator/lib/isIP';
+import { PlatformConfig } from 'homebridge';
+
+export const DEFAULT_OUTLETINUSE_ISACTIVE = false;
+
+export const DEFAULT_OUTLETINUSE_THRESHOLD = 5;
+export const DEFAULT_OUTLETINUSE_THRESHOLD_MIN = 0.1;
+export const DEFAULT_OUTLETINUSE_THRESHOLD_MAX = 3680;
+
+export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION = 10;
+export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MIN = 0;
+export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MAX = 86400;
+
+// validate the config schema from config.schema.json
+export const configSchema = z.object({
+  name: z.string(),
+  energySockets: z.array(
+    z.object({
+      ip: z
+        .string({
+          required_error: 'IP address is required for each Energy Socket',
+        })
+        .refine(
+          ip => isIP(ip, 4),
+          ip => ({
+            message: `${ip} is not a valid IPv4 address`,
+          }),
+        ),
+      name: z.string({
+        required_error: 'Name is required for each Energy Socket',
+      }),
+      outletInUse: z
+        .object({
+          isActive: z.boolean().optional(),
+          threshold: z
+            .number()
+            .min(DEFAULT_OUTLETINUSE_THRESHOLD_MIN)
+            .max(DEFAULT_OUTLETINUSE_THRESHOLD_MAX)
+            .optional(), // set as optional, because it is only required when outletInUse.isActive is true. We'll use superRefine to validate this
+          thresholdDuration: z
+            .number()
+            .min(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MIN)
+            .max(DEFAULT_OUTLETINUSE_THRESHOLD_DURATION_MAX)
+            .optional(), // set as optional, because it is only required when outletInUse.isActive is true. We'll use superRefine to validate this
+        })
+
+        .superRefine((schema, ctx) => {
+          const isActive = schema?.isActive;
+          const threshold = schema?.threshold;
+          const thresholdDuration = schema?.thresholdDuration;
+
+          // If isActive is true, threshold and thresholdDuration are required
+          if (isActive) {
+            if (!threshold) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['threshold'],
+                message: 'A threshold is required when outletInUse.isActive is true',
+              });
+            }
+
+            if (!thresholdDuration) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['thresholdDuration'],
+                message: 'A thresholdDuration is required when outletInUse.isActive is true',
+              });
+            }
+          }
+
+          return z.NEVER;
+        }),
+    }),
+  ),
+});
+
+export type ConfigSchema = z.infer<typeof configSchema> & PlatformConfig;

--- a/src/energy-socket-accessory.ts
+++ b/src/energy-socket-accessory.ts
@@ -15,9 +15,9 @@ import {
   HomeWizardEnergyPlatformAccessoryContext,
   PLATFORM_MANUFACTURER,
 } from '@/api/types';
+import { EnergySocketConfig } from './types';
 
-const POWER_USAGE_THRESHOLD = 5;
-const POLLING_INTERVAL = 3000; // in ms
+const POLLING_INTERVAL = 1000; // in ms
 const SHOW_POLLING_ERRORS_INTERVAL = (15 * 60 * 1000) / POLLING_INTERVAL; // Show error every 15 minutes, if we poll every 3 seconds that's every 300 errors
 
 /**
@@ -32,7 +32,11 @@ export class EnergySocketAccessory {
   private loggerPrefix: string;
   private homeWizardApi: HomeWizardApi;
   private localStateResponse: HomeWizardApiStateResponse | undefined;
+  private config: EnergySocketConfig | undefined;
+
   longPollErrorCount = 0;
+  longPollCrossedThresholdAboveAt: Date | null = null;
+  longPollCrossedThresholdBelowAt: Date | null = null;
 
   constructor(
     private readonly platform: HomebridgeHomeWizardEnergySocket,
@@ -42,6 +46,7 @@ export class EnergySocketAccessory {
     const properties = accessory.context.energySocket;
 
     this.properties = properties;
+    this.config = properties.config;
 
     const loggerPrefix = `[Energy Socket: ${properties.displayName}] -> `;
 
@@ -88,8 +93,12 @@ export class EnergySocketAccessory {
     this.service.setCharacteristic(this.platform.Characteristic.Name, properties.displayName);
 
     // We update this characteristic by polling the /data endpoint
-    // So we set it to false by default, because we don't know the current state yet
-    this.service.setCharacteristic(this.platform.Characteristic.OutletInUse, false);
+    // Set the initial value by using the activePower property from the properties object
+    // When there is no isActive property, we assume the outlet is always in use
+    this.service.setCharacteristic(
+      this.platform.Characteristic.OutletInUse,
+      this.initialIsOutletInUse,
+    );
 
     // Register handlers for the On/Off Characteristic
     this.service
@@ -100,12 +109,116 @@ export class EnergySocketAccessory {
     // Listen for the "identify" event for this Accessory
     this.accessory.on(PlatformAccessoryEvent.IDENTIFY, this.handleIdentify.bind(this));
 
+    this.logCurrentOutletInUseState();
+
     // Start long polling the /data endpoint to get the current power usage
     this.longPollData();
   }
 
+  /**
+   * Get the initial OutletInUse upon instance creation.
+   *
+   * We ignore the thresholdDuration here, because we need to set an initial value, that is either true or false.
+   */
+  get initialIsOutletInUse(): boolean {
+    return this.config?.outletInUse?.isActive &&
+      this.getIsActivePowerAboveThreshold(this.properties.activePower)
+      ? true
+      : false;
+  }
+
+  logCurrentOutletInUseState() {
+    this.platform.log.info(
+      this.loggerPrefix,
+      `OutletInUse value is ${this.isOutletInUse ? 'ON' : 'OFF'} (${
+        this.properties.activePower
+      } watt)`,
+    );
+  }
+
+  get isOutletInUse(): boolean {
+    return this.service.getCharacteristic(this.platform.Characteristic.OutletInUse)
+      .value as boolean;
+  }
+
+  get thresholdDurationInMs(): number {
+    return (this.config?.outletInUse?.thresholdDuration || 0) * 1000;
+  }
+
+  get isThresholdCrossedAboveAfterDuration(): boolean | null {
+    // Return null when config option is not set
+    if (!this.config?.outletInUse?.isActive) {
+      return null;
+    }
+
+    const currentTime = new Date().getTime();
+    const crossedAboveThresholdTime = this.longPollCrossedThresholdAboveAt?.getTime();
+
+    // Return null when we haven't crossed the threshold yet
+    if (!crossedAboveThresholdTime) return null;
+
+    // When the threshold is crossed above, and the duration is passed, return true
+    return currentTime - crossedAboveThresholdTime >= this.thresholdDurationInMs;
+  }
+
+  get isThresholdCrossedBelowAfterDuration(): boolean | null {
+    // Return null when config option is not set
+    if (!this.config?.outletInUse?.isActive) {
+      return null;
+    }
+
+    const currentTime = new Date().getTime();
+    const crossedBelowThresholdTime = this.longPollCrossedThresholdBelowAt?.getTime();
+
+    // Return null when we haven't crossed the threshold yet
+    if (!crossedBelowThresholdTime) return null;
+
+    // When the threshold is crossed below, and the duration is passed, return true
+    return currentTime - crossedBelowThresholdTime >= this.thresholdDurationInMs;
+  }
+
+  setOutletInUse(value: boolean, activePower: number | null | undefined) {
+    this.service.setCharacteristic(this.platform.Characteristic.OutletInUse, value);
+
+    this.longPollCrossedThresholdAboveAt = null;
+    this.longPollCrossedThresholdBelowAt = null;
+
+    this.platform.log.info(
+      this.loggerPrefix,
+      `OutletInUse is changed to ${value ? 'ON' : 'OFF'} (${activePower} watt)`,
+    );
+  }
+
+  getIsActivePowerAboveThreshold(activePower: number | null | undefined): boolean {
+    return !!(activePower && activePower > (this.config?.outletInUse?.threshold || 0));
+  }
+
+  /**
+   * Long poll the /data endpoint to get the current power usage.
+   * This is used to update the OutletInUse characteristic.
+   *
+   * Errors are logged every 15 minutes, to not flood the Homebridge logs.
+   * This is done by counting the number of errors, and only logging an error every X amount of errors.
+   *
+   * The long polling will never stop, unless the plugin is stopped.
+   */
   async longPollData() {
+    if (!this.config?.outletInUse?.isActive) {
+      this.platform.log.debug(
+        this.loggerPrefix,
+        'outletInUse.isActive config option is false or not set, not long polling the /data endpoint',
+      );
+
+      return;
+    }
+
     if (this.properties.productType !== HomeWizardDeviceTypes.WIFI_ENERGY_SOCKET) {
+      // this should not happen, but acts as a type guard
+      this.platform.log.debug(
+        this.loggerPrefix,
+        'Not a Energy Socket, not long polling the /data endpoint',
+      );
+
       return;
     }
 
@@ -113,33 +226,75 @@ export class EnergySocketAccessory {
       // Get the current state of the device
       // We need to pass true as the second argument to disable logging, to not flood the Homebridge logs
       // We'll only log errors here
-      const energySocketData = await this.homeWizardApi.getData(this.properties.productType, true);
+      const { active_power_w } = await this.homeWizardApi.getData(
+        this.properties.productType,
+        true,
+      );
 
-      const outletInUse = this.service.getCharacteristic(
-        this.platform.Characteristic.OutletInUse,
-      ).value;
+      const isActivePowerAboveThreshold = this.getIsActivePowerAboveThreshold(active_power_w);
 
-      const isThresholdMet =
-        energySocketData.active_power_w && energySocketData.active_power_w > POWER_USAGE_THRESHOLD;
-
-      // console.log(
-      //   'active_power_w',
-      //   this.properties.displayName,
-      //   energySocketData.active_power_w,
-      //   'outletInUse?',
-      //   outletInUse,
-      // );
-
-      if (isThresholdMet && !outletInUse) {
-        // If threshold is met, set to true
-        // And only set to true if it's not already true
-        this.service.setCharacteristic(this.platform.Characteristic.OutletInUse, true);
-      } else if (!isThresholdMet && outletInUse) {
-        // If threshold is not met, set to false
-        // And only set to false if it's not already false
-        this.service.setCharacteristic(this.platform.Characteristic.OutletInUse, false);
+      // If threshold is met, set to true
+      // And only set to true if the current isOutletInUse value is false
+      if (isActivePowerAboveThreshold && !this.isOutletInUse) {
+        if (!this.longPollCrossedThresholdAboveAt) {
+          this.longPollCrossedThresholdAboveAt = new Date();
+          // this.longPollCrossedThresholdBelowAt = null;
+        }
       }
 
+      // If threshold is not met, set to false
+      // And only set to false if the current isOutletInUse value is true
+      if (!isActivePowerAboveThreshold && this.isOutletInUse) {
+        if (!this.longPollCrossedThresholdBelowAt) {
+          // this.longPollCrossedThresholdAboveAt = null;
+          this.longPollCrossedThresholdBelowAt = new Date();
+        }
+      }
+
+      // Specifically check for true, because it could be null
+      if (this.isThresholdCrossedAboveAfterDuration === true && !this.isOutletInUse) {
+        this.platform.log.debug(
+          this.loggerPrefix,
+          `OutletInUse threshold crossed above ${this.config.outletInUse.threshold} watt for ${this.config.outletInUse.thresholdDuration} seconds, set OutletInUse to true`,
+        );
+
+        this.setOutletInUse(true, active_power_w);
+      }
+
+      // Specifically check for false, because it could be null
+      if (this.isThresholdCrossedBelowAfterDuration === true && this.isOutletInUse) {
+        this.platform.log.debug(
+          this.loggerPrefix,
+          `OutletInUse threshold crossed below ${this.config.outletInUse.threshold} watt for ${this.config.outletInUse.thresholdDuration} seconds, set OutletInUse to false`,
+        );
+
+        this.setOutletInUse(false, active_power_w);
+      }
+
+      // Verbose logging for debug purposes while developing
+      // this.platform.log.debug(
+      //   'active_power_w',
+      //   this.properties.displayName,
+      //   active_power_w?.toFixed(3),
+      //   'outletInUse?',
+      //   this.isOutletInUse,
+      //   'longPollCrossedThresholdAboveAt',
+      //   this.longPollCrossedThresholdAboveAt?.toLocaleTimeString('nl-NL', {
+      //     hour: '2-digit',
+      //     minute: '2-digit',
+      //     second: '2-digit',
+      //   }),
+      //   'longPollCrossedThresholdBelowAt',
+      //   this.longPollCrossedThresholdBelowAt?.toLocaleTimeString('nl-NL', {
+      //     hour: '2-digit',
+      //     minute: '2-digit',
+      //     second: '2-digit',
+      //   }),
+      //   'crossedAbove?',
+      //   this.isThresholdCrossedAboveAfterDuration,
+      // );
+
+      // Reset the error count, because we received a response
       this.longPollErrorCount = 0;
 
       // Always run the setTimeout after above logic
@@ -151,14 +306,20 @@ export class EnergySocketAccessory {
         errorMessage = error.message;
       }
 
-      // If error threshold is met, show an error
-      if (this.longPollErrorCount > SHOW_POLLING_ERRORS_INTERVAL) {
+      const isFirstError = this.longPollErrorCount === 0;
+      const isErrorCountAfterInterval = this.longPollErrorCount > SHOW_POLLING_ERRORS_INTERVAL;
+
+      // Only show the error if it's the first error or the last error
+      // The first error to not wait for the SHOW_POLLING_ERRORS_INTERVAL to show any error
+      if (isErrorCountAfterInterval || isFirstError) {
         this.platform.log.error(
           this.loggerPrefix,
           'Error during polling the data endpoint',
           errorMessage,
         );
+      }
 
+      if (isErrorCountAfterInterval) {
         // Reset the counter after showing the error
         this.longPollErrorCount = 0;
       } else {
@@ -241,6 +402,8 @@ export class EnergySocketAccessory {
         this.loggerPrefix,
         `Energy Socket state is updated to ${response.power_on ? 'ON' : 'OFF'}`,
       );
+
+      // TODO: set OutletInUse to false if power_on is false. Do not set to true if power_on is true, because the outletInUse is set by the longPollData method. When an energy socket is turned on, we don't know if the device connected to it is drawing power.
     } catch (error) {
       const fallbackErrorMessage = 'A unknown error occurred while setting the ON state';
 

--- a/src/energy-socket-accessory.ts
+++ b/src/energy-socket-accessory.ts
@@ -229,7 +229,9 @@ export class EnergySocketAccessory {
   }
 
   /**
-   * Keep the OutletInUse characteristic in sync with the ON state if the config for outletInUse is not set
+   * Keep the OutletInUse characteristic in sync with the ON state if the config for outletInUse is not set.
+   *
+   * Only setting the OutletInUse characteristic when the config is not set, because when the config is set, the OutletInUse characteristic is set by the long polling.
    */
   syncOutletInUseStateWithOnState(isOn: boolean) {
     if (!this.config?.outletInUse?.isActive) {
@@ -414,7 +416,7 @@ export class EnergySocketAccessory {
 
       this.log.info(`Energy Socket On state is updated to ${isOn ? 'ON' : 'OFF'}`);
 
-      // Keep the OutletInUse characteristic in sync with the ON state if the config for outletInUse is not set
+      // Keep the OutletInUse characteristic in sync with the ON/OFF state if the config for outletInUse is not set
       this.syncOutletInUseStateWithOnState(isOn);
     } catch (error) {
       const fallbackErrorMessage = 'A unknown error occurred while setting the ON state';

--- a/src/energy-socket-accessory.ts
+++ b/src/energy-socket-accessory.ts
@@ -119,12 +119,16 @@ export class EnergySocketAccessory {
    * Get the initial OutletInUse upon instance creation.
    *
    * We ignore the thresholdDuration here, because we need to set an initial value, that is either true or false.
+   *
+   * When there is no isActive config property, we assume the outlet is always in use
    */
   get initialIsOutletInUse(): boolean {
-    return this.config?.outletInUse?.isActive &&
-      this.getIsActivePowerAboveThreshold(this.properties.activePower)
-      ? true
-      : false;
+    // When there is no isActive config property, we assume the outlet is always in use
+    if (!this.config?.outletInUse?.isActive) {
+      return true;
+    }
+
+    return this.getIsActivePowerAboveThreshold(this.properties.activePower);
   }
 
   logCurrentOutletInUseState() {

--- a/src/mocks/energy-socket-accessory.ts
+++ b/src/mocks/energy-socket-accessory.ts
@@ -22,4 +22,5 @@ export const mockAccessoryContext = {
   uuid: mockUUID,
   firmwareVersion: mockFirmwareVersion,
   apiVersion: mockApiVersion,
+  activePower: null,
 } satisfies EnergySocketAccessoryProperties;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -10,7 +10,12 @@ import {
 } from 'homebridge';
 import { Bonjour, Service as BonjourService } from 'bonjour-service';
 
-import { PLATFORM_NAME, PLUGIN_NAME } from '@/settings';
+import {
+  DEFAULT_OUTLETINUSE_THRESHOLD,
+  DEFAULT_OUTLETINUSE_THRESHOLD_DURATION,
+  PLATFORM_NAME,
+  PLUGIN_NAME,
+} from '@/settings';
 import { EnergySocketAccessory } from '@/energy-socket-accessory';
 import {
   EnergySocketAccessoryProperties,
@@ -396,6 +401,17 @@ export class HomebridgeHomeWizardEnergySocket implements DynamicPlatformPlugin {
 
       const displayName = configName ? configName : `${productName} ${serialNumber}`; // "Energy Socket 3c12e7659852", which is used as the name in HomeKit
 
+      const energySocketConfigWithDefaults = {
+        ...energySocketConfig,
+        outletInUse: {
+          ...energySocketConfig?.outletInUse,
+          threshold: energySocketConfig?.outletInUse?.threshold || DEFAULT_OUTLETINUSE_THRESHOLD,
+          thresholdDuration:
+            energySocketConfig?.outletInUse?.thresholdDuration ||
+            DEFAULT_OUTLETINUSE_THRESHOLD_DURATION,
+        },
+      } satisfies EnergySocketConfig;
+
       const energySocketProperties = {
         uuid,
         ip,
@@ -407,7 +423,7 @@ export class HomebridgeHomeWizardEnergySocket implements DynamicPlatformPlugin {
         productType,
         firmwareVersion,
         activePower,
-        config: energySocketConfig,
+        config: energySocketConfigWithDefaults,
       } satisfies EnergySocketAccessoryProperties;
 
       this.log.debug(

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -350,7 +350,7 @@ export class HomebridgeHomeWizardEnergySocket implements DynamicPlatformPlugin {
 
       const firmwareVersion = basicInformation.firmware_version;
       const productName = basicInformation.product_name;
-      const productType = basicInformation.product_type;
+      const productType = basicInformation.product_type as HomeWizardDeviceTypes; // TODO: check for valid product type
       const serialNumber = basicInformation.serial;
       const apiVersion = basicInformation.api_version;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,3 @@ export const PLATFORM_NAME = 'HomebridgeHomeWizardEnergySocket';
  * This must match the name of your plugin as defined the package.json
  */
 export const PLUGIN_NAME = 'homebridge-homewizard-energy-socket';
-
-export const DEFAULT_OUTLETINUSE_THRESHOLD = 5;
-export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION = 10;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,3 +9,6 @@ export const PLATFORM_NAME = 'HomebridgeHomeWizardEnergySocket';
  * This must match the name of your plugin as defined the package.json
  */
 export const PLUGIN_NAME = 'homebridge-homewizard-energy-socket';
+
+export const DEFAULT_OUTLETINUSE_THRESHOLD = 5;
+export const DEFAULT_OUTLETINUSE_THRESHOLD_DURATION = 10;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,22 @@
 import { PlatformConfig } from 'homebridge';
 
+/**
+ * See config.schema.json for the configuration options.
+ *
+ * All properties are optional, even if the config.schema.json says otherwise.
+ * Because the user can adjust the config schema manually, we cannot entirely rely on the config.schema.json to be the source of truth.
+ */
 export interface EnergySocketConfig {
-  name: string;
-  ip: string;
+  name?: string;
+  ip?: string;
+  outletInUse?: {
+    /** When enabled, the "OutletInUse" characteristic will be shown as "Yes" if the Energy Socket is drawing power. You can trigger automations based on this characteristic. By default this characteristic is "No". */
+    isActive?: boolean;
+    /** When the power consumption is higher than this threshold, the "OutletInUse" characteristic will be shown as "Yes" in the Home app. Defaults to 1 watt. */
+    threshold?: number;
+    /** When the power consumption is higher than the threshold for this duration, the "OutletInUse" characteristic will be shown as "Yes" in the Home app. Defaults to 10 seconds. */
+    thresholdDuration?: number;
+  };
 }
 
 /**
@@ -11,3 +25,7 @@ export interface EnergySocketConfig {
 export interface HomebridgeHomeWizardEnergySocketsConfig extends PlatformConfig {
   energySockets?: EnergySocketConfig[];
 }
+
+export type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
+  [Property in Key]-?: Type[Property];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import { PlatformConfig } from 'homebridge';
-
 /**
  * See config.schema.json for the configuration options.
  *
@@ -17,13 +15,6 @@ export interface EnergySocketConfig {
     /** When the power consumption is higher than the threshold for this duration, the "OutletInUse" characteristic will be shown as "Yes" in the Home app. Defaults to 10 seconds. */
     thresholdDuration?: number;
   };
-}
-
-/**
- * See config.schema.json for the configuration options.
- */
-export interface HomebridgeHomeWizardEnergySocketsConfig extends PlatformConfig {
-  energySockets?: EnergySocketConfig[];
 }
 
 export type WithRequiredProperty<Type, Key extends keyof Type> = Type & {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Checks if `value` is `null` or `undefined`.
+ *
+ * @example
+ *```
+ * isNil(null); // => true
+ * isNil(void 0); // => true
+ * isNil(NaN); // => false
+ * ```
+ */
+export function isNil<T>(value?: T | null): value is null | undefined {
+  return value === null || value === undefined;
+}


### PR DESCRIPTION
To be used in automations

- [x] Set OutletInUse to false when On characteristic is Off
- [x] Use zod for config validation
- [x] Always show the first error on the polling interval and hide other errors for 15 minutes to prevent flooding the Homebridge log with errors
- [x] Let user define a threshold in the config for each energy socket
- [x] Set default behaviour of OutletInUse: when nothing is configured, it should follow the same value as the `On` characteristic
- [x] Update docs https://github.com/jvandenaardweg/homebridge-homewizard-energy-socket/wiki/About-the-Outlet-In-Use-characteristic

Will do in a later version:
- Create separate switch accessory to allow automations in the Home App